### PR TITLE
Include pkg-config in list of tools needed for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ In order to install PostgreSQL dependencies run:
 
 ```
 # for basic build
-sudo apt install gcc make flex bison libreadline-dev zlib1g-dev \
-  libssl-dev libxml2-dev libxslt1-dev libipc-run-perl
+sudo apt install gcc make flex bison pkg-config libreadline-dev \
+  zlib1g-dev libssl-dev libxml2-dev libxslt1-dev libipc-run-perl
 
 # to build the documentation as well
 sudo apt install docbook docbook-dsssl docbook-xsl libxml2-utils \


### PR DESCRIPTION
My build was failing with ICU libraries related errors on Ubuntu even after necessary libraries were installed. Installing `pkg-config` solved the issue. Need of `pkg-config` is mentioned in postgresql's installation doc, but looks like its kind of necessary to have it installed always.